### PR TITLE
Added add_constraint with unique and deferrable options.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -545,6 +545,12 @@ module ActiveRecord
       # The constraint will be named after the table and the column name(s), unless
       # you pass <tt>:name</tt> as an option.
       #
+      # Note on UNIQUE index:
+      # Adding a *unique* constraint will automatically create a unique index on the column(s) specified.
+      # It is unnecessary to use both add_index and add_constraint in this case, as the query planner will
+      # be able to use the one created with add_constraint(..., unique: true).
+      # This is the case in both mysql and postgres.
+      #
       # ====== Creating a simple unique constraint
       #
       #   add_constraint(:accounts, [:branch_id, :party_id], unique: true)
@@ -906,6 +912,7 @@ module ActiveRecord
         constraint_name    = constraint_name(table_name, column: column_names)
         constraint_columns = quoted_columns_for_constraint(column_names, options).join(", ")
         constraint_type    = options[:unique] ? "UNIQUE" : ""
+        constraint_name    = options[:name].to_s if options.key?(:name)
 
         if supports_deferrable_constraints?
           constraint_options = options[:deferrable] ? " DEFERRABLE INITIALLY IMMEDIATE" : ""

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -239,6 +239,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support creating deferrable constraints?
+      def supports_deferrable_constraints?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -127,6 +127,19 @@ module ActiveRecord
           SQL
         end
 
+        # WIP...
+        def constraints(table_name, name = nil)
+           result = query(<<-SQL, 'SCHEMA')
+             SELECT distinct i.relname, d.contype, d.condeferrable, pg_get_constraintdef(d.oid), t.oid
+             FROM pg_class t
+             INNER JOIN pg_constraint d ON t.oid = d.conrelid
+             INNER JOIN pg_class i ON d.conindid = i.oid
+             WHERE t.relname = '#{table_name}'
+               AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = ANY (current_schemas(false)) )
+            ORDER BY i.relname
+          SQL
+        end
+
         def index_name_exists?(table_name, index_name, default)
           exec_query(<<-SQL, 'SCHEMA').rows.first[0].to_i > 0
             SELECT COUNT(*)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -163,6 +163,10 @@ module ActiveRecord
         true
       end
 
+      def supports_deferrable_constraints?
+        true
+      end
+
       def index_algorithms
         { concurrently: 'CONCURRENTLY' }
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -184,6 +184,11 @@ HEADER
         stream
       end
 
+      # FIXME: Dump constraints here
+      def constraints(table, stream)
+      end
+
+      # FIXME: Do not dump constraints here
       def indexes(table, stream)
         if (indexes = @connection.indexes(table)).any?
           add_index_statements = indexes.map do |index|

--- a/activerecord/test/cases/adapters/mysql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql/active_schema_test.rb
@@ -59,6 +59,22 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     assert_equal expected, add_index(:people, [:last_name, :first_name], :length => 15, :using => :btree)
   end
 
+  def test_add_constraint
+    expected = %(ALTER TABLE `accounts` ADD CONSTRAINT `constraint_accounts_on_branch_id` UNIQUE (`branch_id`))
+    assert_equal expected, add_constraint(:accounts, :branch_id, unique: true)
+
+    expected = %(ALTER TABLE `accounts` ADD CONSTRAINT `constraint_accounts_on_branch_id_and_party_id` UNIQUE (`branch_id`, `party_id`))
+    assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true)
+
+    # Deferrable have no effect in mysql
+    expected = %(ALTER TABLE `accounts` ADD CONSTRAINT `constraint_accounts_on_branch_id_and_party_id` UNIQUE (`branch_id`, `party_id`))
+    assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true, deferrable: true)
+
+    assert_raise ArgumentError do
+      add_constraint(:accounts, [:branch_id, :party_id])
+    end
+  end
+
   def test_drop_table
     assert_equal "DROP TABLE `people`", drop_table(:people)
   end

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -59,6 +59,22 @@ class ActiveSchemaTest < ActiveRecord::TestCase
     assert_equal expected, add_index(:people, [:last_name, :first_name], :length => 15, :using => :btree)
   end
 
+  def test_add_constraint
+    expected = %(ALTER TABLE `accounts` ADD CONSTRAINT `constraint_accounts_on_branch_id` UNIQUE (`branch_id`))
+    assert_equal expected, add_constraint(:accounts, :branch_id, unique: true)
+
+    expected = %(ALTER TABLE `accounts` ADD CONSTRAINT `constraint_accounts_on_branch_id_and_party_id` UNIQUE (`branch_id`, `party_id`))
+    assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true)
+
+    # Deferrable have no effect in mysql2
+    expected = %(ALTER TABLE `accounts` ADD CONSTRAINT `constraint_accounts_on_branch_id_and_party_id` UNIQUE (`branch_id`, `party_id`))
+    assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true, deferrable: true)
+
+    assert_raise ArgumentError do
+      add_constraint(:accounts, [:branch_id, :party_id])
+    end
+  end
+
   def test_drop_table
     assert_equal "DROP TABLE `people`", drop_table(:people)
   end

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -23,6 +23,21 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
     assert_equal %(CREATE DATABASE "aimonetti" ENCODING = 'UTF8' LC_COLLATE = 'ja_JP.UTF8' LC_CTYPE = 'ja_JP.UTF8'), create_database(:aimonetti, :encoding => :"UTF8", :collation => :"ja_JP.UTF8", :ctype => :"ja_JP.UTF8")
   end
 
+  def test_add_constraint
+    expected = %(ALTER TABLE "accounts" ADD CONSTRAINT "constraint_accounts_on_branch_id" UNIQUE ("branch_id"))
+    assert_equal expected, add_constraint(:accounts, :branch_id, unique: true)
+
+    expected = %(ALTER TABLE "accounts" ADD CONSTRAINT "constraint_accounts_on_branch_id_and_party_id" UNIQUE ("branch_id", "party_id"))
+    assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true)
+
+    expected = %(ALTER TABLE "accounts" ADD CONSTRAINT "constraint_accounts_on_branch_id_and_party_id" UNIQUE ("branch_id", "party_id") DEFERRABLE INITIALLY IMMEDIATE)
+    assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true, deferrable: true)
+
+    assert_raise ArgumentError do
+      add_constraint(:accounts, [:branch_id, :party_id], deferrable: true)
+    end
+  end
+
   def test_add_index
     # add_index calls index_name_exists? which can't work since execute is stubbed
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.stubs(:index_name_exists?).returns(false)

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -27,6 +27,9 @@ class PostgresqlActiveSchemaTest < ActiveRecord::TestCase
     expected = %(ALTER TABLE "accounts" ADD CONSTRAINT "constraint_accounts_on_branch_id" UNIQUE ("branch_id"))
     assert_equal expected, add_constraint(:accounts, :branch_id, unique: true)
 
+    expected = %(ALTER TABLE "accounts" ADD CONSTRAINT "my_custom_name" UNIQUE ("branch_id"))
+    assert_equal expected, add_constraint(:accounts, :branch_id, name: "my_custom_name", unique: true)
+
     expected = %(ALTER TABLE "accounts" ADD CONSTRAINT "constraint_accounts_on_branch_id_and_party_id" UNIQUE ("branch_id", "party_id"))
     assert_equal expected, add_constraint(:accounts, [:branch_id, :party_id], unique: true)
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -311,6 +311,14 @@ module ActiveRecord
         assert_equal Arel.sql('$2'), bind
       end
 
+      def test_unique_constraint_adds_unique_index
+        with_example_table do
+          @connection.add_constraint 'ex', %w{ id number }, name: 'unique_id_number', unique: true
+          index = @connection.indexes('ex').find { |idx| idx.name == 'unique_id_number' }
+          assert_equal true, index.unique
+        end
+      end
+
       def test_partial_index
         with_example_table do
           @connection.add_index 'ex', %w{ id number }, :name => 'partial', :where => "number > 100"

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -319,6 +319,20 @@ module ActiveRecord
         end
       end
 
+      # WIP: Either I need to fix .constraints and dump add_constraint in schema dumper, but there is lack of support of getting
+      # constraints info in pg_get_constraintdef:
+      def test_unique_deferrable_constraint
+        with_example_table do
+          @connection.add_constraint 'ex', %w{ id number }, name: 'unique_id_number', unique: true, deferrable: true
+          index = @connection.indexes('ex').find { |idx| idx.name == 'unique_id_number' }
+          puts index
+          puts @connection
+          puts @connection.methods.grep /constraint/
+          puts @connection.constraints('ex')
+          assert_equal true, index.unique
+        end
+      end
+
       def test_partial_index
         with_example_table do
           @connection.add_index 'ex', %w{ id number }, :name => 'partial', :where => "number > 100"


### PR DESCRIPTION
Placeholder pull request to my own repository as this is a WIP
- Add a new `remove_constraint` method + specs
- Fix the schema dumper to report correctly + specs ( see https://github.com/rails/rails/pull/4956/files )
- Specs: `skip 'only on pg' unless current_adapter?(:PostgreSQLAdapter)`

Also see original closed PR
- https://github.com/AEAB/journalsystem-vet/pull/578/files

Also see the primer
- http://hashrocket.com/blog/posts/deferring-database-constraints
